### PR TITLE
MongoDBの設定修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 __debug_bin
 
 .env
+!docker/.env
 main_server
 **/db/*
 *.csv

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=library-app-server

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       context: ../
       dockerfile: ./docker/mongodb/Dockerfile
     environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-root}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-password}
     ports:
       - 27017:27017
     volumes:
@@ -18,6 +18,13 @@ services:
       dockerfile: ./docker/golang/Dockerfile
     stdin_open: true
     tty: true
+    environment:
+      DB_HOST: mongodb
+      DB_PORT: 27017
+      DB_USER: ${MONGO_INITDB_ROOT_USERNAME:-root}
+      DB_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-password}
+      DATABASE_NAME: library-app
+      COLLECTION_NAME: books
     ports:
       - 1313:1313
     working_dir: /go/src/app

--- a/initdb/initdb.sh
+++ b/initdb/initdb.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-mongoimport --db=library-app --collection=books  --type csv --file /docker-entrypoint-initdb.d/initdata.csv --headerline --columnsHaveTypes -u root -p password --authenticationDatabase admin
+mongoimport --db=library-app --collection=books  --type csv --file /docker-entrypoint-initdb.d/initdata.csv --headerline --columnsHaveTypes -u ${MONGO_INITDB_ROOT_USERNAME:-root} -p ${MONGO_INITDB_ROOT_PASSWORD:-password} --authenticationDatabase admin
 # borrowerの空配列を追加
 /add_borrower
 # docker buildの際に権限エラーにならないように権限付与


### PR DESCRIPTION
* username, passwordを`.env`で設定できるように`docker-compose.yml`を修正
  * `.env`で設定しない場合はデフォルト値を使用
* golangのコンテナがルートの`.env`に影響しないよう修正
  * `godotenv`の`Load`は環境変数が優先([参考](https://zenn.dev/keyamin/articles/4dbcce8f214bfe))