### PR TITLE
warningの修正

### DIFF
--- a/Book_MongoDB.go
+++ b/Book_MongoDB.go
@@ -1,20 +1,20 @@
 package main
 
 type BookMongoDB struct {
-	Id         int64       `json:"id", bson:"id"`
-	BookName   string      `json:"bookName", bson:"bookName"`
-	Genre      string      `json:"genre", bson:"genre"`
-	SubGenre   string      `json:"subGenre", bson:"subGenre"`
-	ISBN       string      `json:"ISBN", bson:"ISBN"`
-	Find       int64       `json:"find", bson:"find"`
-	Sum        int64       `json:"sum", bson:"sum"`
-	Author     string      `json:"author", bson:"author"`
-	Publisher  string      `json:"publisher", bson:"publisher"`
-	Pubdate    string      `json:"pubdate", bson:"pubdate"`
-	Exist      string      `json:"exist", bson:"exist"`
-	LocateAt4F bool        `json:"locateAt4F", bson:"locateAt4F"`
-	WithDisc   string      `json:"withDisc", bson:"withDisc"`
-	Other      string      `json:"other", bson:"other"`
-	Borrower   interface{} `json:"borrower", bson:"borrower"`
-	ImgURL     string      `json:"imgURL", bson:"imgURL"`
+	Id         int64       `json:"id" bson:"id"`
+	BookName   string      `json:"bookName" bson:"bookName"`
+	Genre      string      `json:"genre" bson:"genre"`
+	SubGenre   string      `json:"subGenre" bson:"subGenre"`
+	ISBN       string      `json:"ISBN" bson:"ISBN"`
+	Find       int64       `json:"find" bson:"find"`
+	Sum        int64       `json:"sum" bson:"sum"`
+	Author     string      `json:"author" bson:"author"`
+	Publisher  string      `json:"publisher" bson:"publisher"`
+	Pubdate    string      `json:"pubdate" bson:"pubdate"`
+	Exist      string      `json:"exist" bson:"exist"`
+	LocateAt4F bool        `json:"locateAt4F" bson:"locateAt4F"`
+	WithDisc   string      `json:"withDisc" bson:"withDisc"`
+	Other      string      `json:"other" bson:"other"`
+	Borrower   interface{} `json:"borrower" bson:"borrower"`
+	ImgURL     string      `json:"imgURL" bson:"imgURL"`
 }

--- a/main_server.go
+++ b/main_server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -137,9 +136,6 @@ func searchBooks(c echo.Context) error {
 		delete(result, "_id")
 		book.Book = result
 		bookvalues1 = append(bookvalues1, book)
-		if result["id"].(int64) == 429 {
-			fmt.Println("!!!")
-		}
 	}
 
 	var bookvalues2 BookValues

--- a/main_server.go
+++ b/main_server.go
@@ -97,12 +97,12 @@ func searchBooks(c echo.Context) error {
 	isAndSearch := m["isAndSearch"].(bool)
 	offset, err := strconv.Atoi(t_offset)
 	if err != nil {
-		log.Printf("【Error】", err)
+		log.Println("【Error】", err)
 		panic(err)
 	}
 	limit, err2 := strconv.Atoi(t_limit)
 	if err2 != nil {
-		log.Printf("【Error】", err)
+		log.Println("【Error】", err)
 		panic(err)
 	}
 
@@ -118,7 +118,7 @@ func searchBooks(c echo.Context) error {
 	col := client.Database(DATABASE_NAME).Collection(COLLECTION_NAME)
 
 	var bookvalues1 BookValues
-	filter := bson.D{{"exist", "〇"}}
+	filter := bson.D{{Key: "exist", Value: "〇"}}
 	cursor, err := col.Find(context.TODO(), filter)
 	if err != nil {
 		panic(err)
@@ -143,7 +143,7 @@ func searchBooks(c echo.Context) error {
 	}
 
 	var bookvalues2 BookValues
-	filter = bson.D{{"exist", "一部発見"}}
+	filter = bson.D{{Key: "exist", Value: "一部発見"}}
 	cursor, err = col.Find(context.TODO(), filter)
 	if err != nil {
 		panic(err)
@@ -189,12 +189,12 @@ func searchGenre(c echo.Context) error {
 	t_limit := m["limit"].(string)
 	offset, err := strconv.Atoi(t_offset)
 	if err != nil {
-		log.Printf("【Error】", err)
+		log.Println("【Error】", err)
 		panic(err)
 	}
 	limit, err2 := strconv.Atoi(t_limit)
 	if err2 != nil {
-		log.Printf("【Error】", err)
+		log.Println("【Error】", err)
 		panic(err)
 	}
 
@@ -210,7 +210,7 @@ func searchGenre(c echo.Context) error {
 	col := client.Database(DATABASE_NAME).Collection(COLLECTION_NAME)
 
 	var books []map[string]interface{}
-	filter := bson.D{{"exist", "〇"}, {"genre", genre}}
+	filter := bson.D{{Key: "exist", Value: "〇"}, {Key: "genre", Value: genre}}
 	cursor, err := col.Find(context.TODO(), filter)
 	if err != nil {
 		panic(err)
@@ -226,7 +226,7 @@ func searchGenre(c echo.Context) error {
 		books = append(books, book)
 	}
 
-	filter = bson.D{{"exist", "一部発見"}, {"genre", genre}}
+	filter = bson.D{{Key: "exist", Value: "一部発見"}, {Key: "genre", Value: genre}}
 	cursor, err = col.Find(context.TODO(), filter)
 	if err != nil {
 		panic(err)
@@ -278,12 +278,12 @@ func searchSubGenre(c echo.Context) error {
 	t_limit := m["limit"].(string)
 	offset, err := strconv.Atoi(t_offset)
 	if err != nil {
-		log.Printf("【Error】", err)
+		log.Println("【Error】", err)
 		panic(err)
 	}
 	limit, err2 := strconv.Atoi(t_limit)
 	if err2 != nil {
-		log.Printf("【Error】", err)
+		log.Println("【Error】", err)
 		panic(err)
 	}
 
@@ -299,7 +299,7 @@ func searchSubGenre(c echo.Context) error {
 	col := client.Database(DATABASE_NAME).Collection(COLLECTION_NAME)
 
 	var books []map[string]interface{}
-	filter := bson.D{{"exist", "〇"}, {"subGenre", subGenre}}
+	filter := bson.D{{Key: "exist", Value: "〇"}, {Key: "subGenre", Value: subGenre}}
 	cursor, err := col.Find(context.TODO(), filter)
 	if err != nil {
 		panic(err)
@@ -315,7 +315,7 @@ func searchSubGenre(c echo.Context) error {
 		books = append(books, book)
 	}
 
-	filter = bson.D{{"exist", "一部発見"}, {"subGenre", subGenre}}
+	filter = bson.D{{Key: "exist", Value: "一部発見"}, {Key: "subGenre", Value: subGenre}}
 	cursor, err = col.Find(context.TODO(), filter)
 	if err != nil {
 		panic(err)
@@ -366,7 +366,7 @@ func borrowBook(c echo.Context) error {
 	name := m["name"].(string)
 	id, err := strconv.Atoi(t_id)
 	if err != nil {
-		log.Printf("【Error】", err)
+		log.Println("【Error】", err)
 		panic(err)
 	}
 
@@ -405,7 +405,7 @@ func returnBook(c echo.Context) error {
 	name := m["name"].(string)
 	id, err := strconv.Atoi(t_id)
 	if err != nil {
-		log.Printf("【Error】", err)
+		log.Println("【Error】", err)
 		panic(err)
 	}
 


### PR DESCRIPTION
* structの定義で不必要なカンマを削除
* `Printf`を使う必要のない部分を`Println`に修正
* `bson.D`の記述を`Key, Value`を使うように修正
  * 参考：[mongo-go-driverでクエリを書く時「primitive.E composite literal uses unkeyed fields」のwarningが表示される - Qiita](https://qiita.com/someone7140/items/3ddd50afd7d6d25425a8)
* 消し忘れていたデバッグコードの削除