### PR TITLE
データの更新手順を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ go run add_borrower/add_borrower.go
 `.devcontainer`はVSCodeのDev Containerで使うための設定であり，本リポジトリをマウントします．
 
 `docker`はサーバを起動するように設定しているため，`docker compose up`でサーバが起動します．
+
+# データの更新手順
+1. 更新データを用意し`initdb/update/updatedata.csv`に配置
+  * id列は今のところ手作業で振る
+2. `docker exec -it library-app-server-mongodb-1 sh /docker-entrypoint-initdb.d/update/update.sh`
+  * コンテナ名が異なる場合は適切なコンテナ名に変更する

--- a/initdb/initdb.sh
+++ b/initdb/initdb.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-mongoimport --db=library-app --collection=books  --type csv --file /docker-entrypoint-initdb.d/initdata.csv --headerline --columnsHaveTypes -u ${MONGO_INITDB_ROOT_USERNAME:-root} -p ${MONGO_INITDB_ROOT_PASSWORD:-password} --authenticationDatabase admin
+mongoimport --db=library-app --collection=books --type csv --file /docker-entrypoint-initdb.d/initdata.csv --headerline --columnsHaveTypes -u ${MONGO_INITDB_ROOT_USERNAME:-root} -p ${MONGO_INITDB_ROOT_PASSWORD:-password} --authenticationDatabase admin
 # borrowerの空配列を追加
 /add_borrower
 # docker buildの際に権限エラーにならないように権限付与

--- a/initdb/update/update.sh
+++ b/initdb/update/update.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mongoimport --db=library-app --collection=books --type csv --file /docker-entrypoint-initdb.d/update/updatedata.csv --mode=merge --upsertFields=id --headerline --columnsHaveTypes -u ${MONGO_INITDB_ROOT_USERNAME:-root} -p ${MONGO_INITDB_ROOT_PASSWORD:-password} --authenticationDatabase admin
+# 新しい本にborrowerの空配列を追加
+/add_borrower


### PR DESCRIPTION
* 元データに影響しないようにデータを追加できるように手順を追加
  * `mongoimport`の`--mode=merge`オプションを使い，既存のデータがcsvファイルに含まれる場合でも影響を与えない
  * `add_borrower.go`でborrowerの配列がないもののみ空配列を追加するように変更